### PR TITLE
add docker container pull link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ For development:
     - Add JDBC jar files to vendor/jar/jdbc in your logstash installation
   - And then configure (examples can be found in the examples directory)
 
+## Docker Container
+- Ready to use container with plugin installed could be pulled from docker hub.
+    `docker pull delatitude/logstash-postgresql-output:latest`
+
 ## Configuration options
 
 | Option                       | Type             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Required? | Default |


### PR DESCRIPTION
It would be easy if one can get hands on a ready made container with every thing installed for this plugin. Logstash: 6.5.4; JRE : 42.1.4
Here is code to dockerfile of container image. https://github.com/delatitude/logstash-postgresql-output/blob/master/Dockerfile